### PR TITLE
VOOD-1101: Add support for Candybean 2.0 with class name changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>candybean</artifactId>
 	<packaging>jar</packaging>
 	<name>candybean</name>
-	<version>1.1.2-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<description>A highly configurable testing framework that seeks to automate across web and mobile while encapsulating common testing features.</description>
 	<url>http://sugarcrm.github.io/candybean/</url>
 	<licenses>

--- a/src/main/java/com/sugarcrm/candybean/automation/Candybean.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/Candybean.java
@@ -71,7 +71,6 @@ public final class Candybean {
 	 */
 	public final Logger log;
 	
-
 	/**
 	 * Instantiates a Candybean object.
 	 * 


### PR DESCRIPTION
The original 2.0 code introduces `getLogger()` for good practice. However, this is blocking us from supporting name changes and loose coupling in Candybean 2.0 smoothly in VOOD-1101 (as `getLogger()` will introduce changes in many places). Also, there is already another ticket for this, so the scope of this PR is to keep the log we had previously in 1.0. Another PR will address the `getLogger()` issue.

Also, the version of Candybean is now updated to 2.0.0.
