### PR TITLE
Explicit Waits

### DIFF
--- a/candybean.config
+++ b/candybean.config
@@ -36,9 +36,11 @@ browser.chrome.driver.path = {\
 browser.chrome.driver.log.path = ./log/chromedriver.log
 
 browser.ie.driver.path = ./lib/IEDriverServer-64.exe
-        
+
+# Wait and Timeout
 perf.page.load.timeout = 2
 perf.implicit.wait.seconds = 20
+perf.explicit.wait.seconds = 15
 
 # Logging
 handlers = java.util.logging.FileHandler, java.util.logging.ConsoleHandler

--- a/src/main/java/com/sugarcrm/candybean/automation/element/Hook.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/element/Hook.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 
+import com.sugarcrm.candybean.exceptions.CandybeanException;
+import org.openqa.selenium.By;
 import com.sugarcrm.candybean.configuration.Configuration;
 import com.sugarcrm.candybean.exceptions.MalformedHookException;
 import com.thoughtworks.selenium.SeleniumException;
@@ -95,6 +97,44 @@ public class Hook {
 		default:
 			throw new SeleniumException("Selenium: Strategy not recognized: " + strategy);
 		}
+	}
+
+	/**
+	 * A helper method to convert Hook to By
+	 * @param hook	The hook that specifies a web element
+	 * @return		The converted By
+	 * @throws CandybeanException
+	 */
+	public static By getBy(Hook hook) throws CandybeanException {
+		switch (hook.hookStrategy) {
+			case CSS:
+				return By.cssSelector(hook.hookString);
+			case XPATH:
+				return By.xpath(hook.hookString);
+			case ID:
+				return By.id(hook.hookString);
+			case NAME:
+				return By.name(hook.hookString);
+			case LINK:
+				return By.linkText(hook.hookString);
+			case PLINK:
+				return By.partialLinkText(hook.hookString);
+			case CLASS:
+				return By.className(hook.hookString);
+			case TAG:
+				return By.tagName(hook.hookString);
+			default:
+				throw new CandybeanException("Strategy type not recognized.");
+		}
+	}
+
+	/**
+	 * A helper method to convert Hook to By
+	 * @return		The converted By
+	 * @throws CandybeanException
+	 */
+	public By getBy() throws CandybeanException {
+		return this.getBy(this);
 	}
 	
 	public String toString() {

--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WaitConditions.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WaitConditions.java
@@ -1,0 +1,340 @@
+package com.sugarcrm.candybean.automation.webdriver;
+
+import com.sugarcrm.candybean.automation.element.Hook;
+import com.sugarcrm.candybean.exceptions.CandybeanException;
+import org.openqa.selenium.*;
+import org.openqa.selenium.support.ui.ExpectedCondition;
+import org.openqa.selenium.support.ui.ExpectedConditions;
+import static com.sugarcrm.candybean.automation.element.Hook.getBy;
+
+/**
+ * This is a list of available wait conditions for WebDriverPause. It is a mix of default Selenium
+ * conditions and custom conditions that implements the interface ExpectedCondition<RETURN_TYPE>.
+ *
+ * @author Eric Tam <etam@sugarcrm.com>
+ */
+public class WaitConditions {
+	private WaitConditions() {
+		// Utility class
+	}
+
+	/**
+	 * A helper method to create a WebDriverElement given Hook and element. Depending on the tag, it will
+	 * return either WebDriverSelector or WebDriverElement
+	 * @param hook
+	 * @param element
+	 * @param driver
+	 * @return
+	 * @throws CandybeanException
+	 */
+	private static WebDriverElement createWebDriverElement(Hook hook, WebElement element, WebDriver driver)
+		throws CandybeanException {
+		if ("select".equals(element.getTagName())) {
+			return new WebDriverSelector(hook, driver);
+		}
+		return new WebDriverElement(hook, 0, driver, element);
+	}
+
+	/**
+	 * A helper method to find element on the page and handles exceptions
+	 * @param hook
+	 * @param driver
+	 * @return
+	 */
+	private static WebElement findElement(Hook hook, WebDriver driver) throws CandybeanException {
+		try {
+			return driver.findElement(getBy(hook));
+		} catch (WebDriverException e) {
+			throw e;
+		}
+	}
+
+	/**
+	 * This returns the negated (logically opposite) condition. It waits until apply() returns null or false
+	 * e.g. Conditions.not(Conditions.visible(...))
+	 * @param	condition the condition you would like to negate
+	 * @return	The negated condition
+	 */
+	public static ExpectedCondition<Boolean> not(ExpectedCondition<?> condition) {
+		return ExpectedConditions.not(condition);
+	}
+
+	/**
+	 * Wait until the element is present on the DOM AND visible
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebDriverElement> visible(final Hook hook) {
+		return new ExpectedCondition<WebDriverElement>() {
+			@Override
+			public WebDriverElement apply(WebDriver driver) {
+				try {
+					WebElement element = findElement(hook, driver);
+					return element.isDisplayed()? createWebDriverElement(hook, element, driver) : null;
+				} catch (CandybeanException | StaleElementReferenceException e) {
+					return null;
+				}
+			}
+
+			@Override
+			public String toString() {
+				return "visibility of " + hook;
+			}
+		};
+	}
+
+	/**
+	 * Wait until the element is present on the DOM AND visible
+	 * @param wde
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebDriverElement> visible(final WebDriverElement wde) {
+		return new ExpectedCondition<WebDriverElement>() {
+			@Override
+			public WebDriverElement apply(WebDriver driver) {
+				try {
+					return wde.isDisplayed()? wde : null;
+				} catch (CandybeanException e) {
+					return null;
+				}
+			}
+
+			@Override
+			public String toString() {
+				return "visibility of " + wde;
+			}
+		};
+	}
+
+	/**
+	 * Wait until the element is not present on the DOM OR invisible
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> invisible(Hook hook) throws CandybeanException {
+		return ExpectedConditions.invisibilityOfElementLocated(getBy(hook));
+	}
+
+	/**
+	 * Wait until the element is not present on the DOM OR invisible
+	 * @param hook
+	 * @param text
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> invisibleWithText(Hook hook, String text) throws CandybeanException {
+		return ExpectedConditions.invisibilityOfElementWithText(getBy(hook), text);
+	}
+
+	/**
+	 * Wait until the element is present on the DOM
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebDriverElement> present(final Hook hook) {
+		return new ExpectedCondition<WebDriverElement>() {
+			@Override
+			public WebDriverElement apply(WebDriver driver) {
+				try {
+					WebElement element = findElement(hook, driver);
+					return createWebDriverElement(hook, element, driver);
+				} catch (CandybeanException | StaleElementReferenceException e) {
+					return null;
+				}
+			}
+
+			@Override
+			public String toString() {
+				return "visibility of " + hook;
+			}
+		};
+	}
+
+	/**
+	 * Wait until the element is clickable state (visible AND enabled)
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebElement> clickable(Hook hook) throws CandybeanException {
+		return ExpectedConditions.elementToBeClickable(getBy(hook));
+	}
+
+	/**
+	 * Wait until the element is clickable state (visible AND enabled)
+	 * @param wde
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebElement> clickable(WebDriverElement wde) {
+		return ExpectedConditions.elementToBeClickable(wde.we);
+	}
+
+	/**
+	 * Wait until the element is selected
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> selected(Hook hook) throws CandybeanException {
+		return ExpectedConditions.elementToBeSelected(getBy(hook));
+	}
+
+	/**
+	 * Wait until the element is selected
+	 * @param wde
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> selected(WebDriverElement wde) {
+		return ExpectedConditions.elementToBeSelected(wde.we);
+	}
+
+	/**
+	 * Wait until the element is unselected
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> unselected(Hook hook) throws CandybeanException {
+		return ExpectedConditions.elementSelectionStateToBe(getBy(hook), false);
+	}
+
+	/**
+	 * Wait until the element is unselected
+	 * @param wde
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> unselected(WebDriverElement wde) {
+		return ExpectedConditions.elementSelectionStateToBe(wde.we, false);
+	}
+
+	/**
+	 * Wait until the frame is available to switch (Polling on switchTo().frame(...) until No NoSuchFrameException) and
+	 * switch to this frame if no exception has occurred
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebDriver> frameToBeAvailableAndSwitchToIt(Hook hook) throws CandybeanException {
+		return ExpectedConditions.frameToBeAvailableAndSwitchToIt(getBy(hook));
+	}
+
+	/**
+	 * Wait until the frame is available to switch (Polling on switchTo().frame(...) until No NoSuchFrameException) and
+	 * switch to this frame if no exception has occurred
+	 * @param name
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<WebDriver> frameToBeAvailableAndSwitchToIt(String name) {
+		return ExpectedConditions.frameToBeAvailableAndSwitchToIt(name);
+	}
+
+	/**
+	 * Wait until the frame is available to switch (Polling on switchTo().frame(...) until No NoSuchFrameException) and
+	 * switch to this frame if no exception has occurred
+	 *
+	 * @param frameIndex used to find the frame using the index
+	 */
+	public static ExpectedCondition<WebDriver> frameToBeAvailableAndSwitchToIt(final int frameIndex) {
+		return new ExpectedCondition<WebDriver>() {
+			@Override
+			public WebDriver apply(WebDriver driver) {
+				try {
+					return driver.switchTo().frame(frameIndex);
+				} catch (NoSuchFrameException e) {
+					return null;
+				}
+			}
+
+			@Override
+			public String toString() {
+				return "frame to be available: " + frameIndex;
+			}
+		};
+	}
+
+	/**
+	 * Wait until the frame is available to switch (Polling on switchTo().frame(...) until No NoSuchFrameException) and
+	 * switch to this frame if no exception has occurred
+	 *
+	 * @param wde used to find the frame using WebDriverElement
+	 */
+	public static ExpectedCondition<WebDriver> frameToBeAvailableAndSwitchToIt(final WebDriverElement wde) {
+		return new ExpectedCondition<WebDriver>() {
+			@Override
+			public WebDriver apply(WebDriver driver) {
+				try {
+					return driver.switchTo().frame(wde.we);
+				} catch (NoSuchFrameException e) {
+					return null;
+				}
+			}
+
+			@Override
+			public String toString() {
+				return "frame to be available: " + wde.toString();
+			}
+		};
+	}
+
+	/**
+	 * Wait until the element is not present on the DOM
+	 * @param wde
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> staleness(WebDriverElement wde) {
+		return ExpectedConditions.stalenessOf(wde.we);
+	}
+
+	/**
+	 * Wait until the expected text presents on the element
+	 * @param hook
+	 * @param text
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> textIsPresent(Hook hook, String text) throws CandybeanException {
+		return ExpectedConditions.textToBePresentInElementLocated(getBy(hook), text);
+	}
+
+	/**
+	 * Wait until the expected text presents on the element
+	 * @param wde
+	 * @param text
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> textIsPresent(WebDriverElement wde, String text) {
+		return ExpectedConditions.textToBePresentInElement(wde.we, text);
+	}
+
+	/**
+	 * Wait until the expected text presents on the element's value attribute
+	 * @param hook
+	 * @param text
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> textIsPresentInValueAttribute(Hook hook, String text) throws CandybeanException {
+		return ExpectedConditions.textToBePresentInElementValue(getBy(hook), text);
+	}
+
+	/**
+	 * Wait until the expected text presents on the element's value attribute
+	 * @param wde
+	 * @param text
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public static ExpectedCondition<Boolean> textIsPresentInValue(WebDriverElement wde, String text) {
+		return ExpectedConditions.textToBePresentInElementValue(wde.we, text);
+	}
+}

--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverElement.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverElement.java
@@ -32,7 +32,6 @@ import org.openqa.selenium.interactions.Actions;
 import com.sugarcrm.candybean.automation.element.Element;
 import com.sugarcrm.candybean.automation.element.Hook;
 import com.sugarcrm.candybean.automation.element.Location;
-import com.sugarcrm.candybean.automation.element.Pause;
 import com.sugarcrm.candybean.automation.element.Hook.Strategy;
 import com.sugarcrm.candybean.exceptions.CandybeanException;
 
@@ -44,8 +43,6 @@ import com.sugarcrm.candybean.exceptions.CandybeanException;
  * @author Conrad Warmbold
  */
 public class WebDriverElement extends Element {
-
-	public Pause pause;
 
 	protected WebDriver wd;
 	protected WebElement we;
@@ -65,19 +62,17 @@ public class WebDriverElement extends Element {
 	public WebDriverElement(Hook hook, int index, WebDriver wd) throws CandybeanException {
 		super(hook, index);
 		this.wd = wd;
-		List<WebElement> wes = this.wd.findElements(WebDriverElement.By(hook));
+		List<WebElement> wes = this.wd.findElements(Hook.getBy(hook));
 		if (wes.size() == 0) {
 			throw new CandybeanException("Control not found; zero web elements returned.");
 		}
 		this.we = wes.get(index);
-		this.pause = new WebDriverPause(this);
 	}
 
 	public WebDriverElement(Hook hook, int index, WebDriver wd, WebElement we) throws CandybeanException {
 		super(hook, index);
 		this.wd = wd;
 		this.we = we;
-		this.pause = new WebDriverPause(this);
 	}
 
 	/**
@@ -199,7 +194,7 @@ public class WebDriverElement extends Element {
 	public Element getSelect(Hook hook, int index) throws CandybeanException {
 		logger.info("Getting select: " + hook.toString() 
 				+ " from element: " + this.toString() + " with index: " + index);
-		WebElement childWe = this.we.findElements(WebDriverSelector.By(hook)).get(index);
+		WebElement childWe = this.we.findElements(Hook.getBy(hook)).get(index);
 		return new WebDriverSelector(hook, index, this.wd, childWe); 
 	}
 
@@ -217,7 +212,7 @@ public class WebDriverElement extends Element {
 	public Element getElement(Hook hook, int index) throws CandybeanException {
 		logger.info("Getting element: " + hook.toString()
 				+ " from element: " + this.toString() + " with index: " + index);
-		WebElement childWe = this.we.findElements(WebDriverElement.By(hook)).get(index);
+		WebElement childWe = this.we.findElements(Hook.getBy(hook)).get(index);
 		return new WebDriverElement(hook, index, this.wd, childWe);
 	}
 
@@ -236,8 +231,7 @@ public class WebDriverElement extends Element {
 	 * to Selenium}
 	 */
 	public boolean isDisplayed() throws CandybeanException {
-		logger.info("Determining if element is visible: "
-				+ this.toString());
+		logger.info("Determining if element is visible: " + this.toString());
 		return we.isDisplayed();
 	}
 
@@ -300,7 +294,7 @@ public class WebDriverElement extends Element {
 		// since this
 		// is the only method that does it and it violates the general
 		// architecture
-		this.we = this.wd.findElements(WebDriverElement.By(this.hook)).get(this.index);
+		this.we = this.wd.findElements(Hook.getBy(this.hook)).get(this.index);
 		this.we.sendKeys(input);
 	}
 
@@ -321,41 +315,17 @@ public class WebDriverElement extends Element {
 			this.sendString(input);
 		else {
 			// Re-find the element to avoid the stale element problem.
-			this.we = this.wd.findElements(WebDriverElement.By(this.hook)).get(this.index);
+			this.we = this.wd.findElements(Hook.getBy(this.hook)).get(this.index);
 			this.we.sendKeys(input);
 		}
 	}
 
+	/**
+	 * Get the By using the hook in this WebDriverElement
+	 * @return
+	 * @throws CandybeanException
+	 */
 	public By getBy() throws CandybeanException {
-		return WebDriverElement.By(this.hook);
-	}
-
-	public static By By(Hook hook) throws CandybeanException {
-		return WebDriverElement.By(hook.getHookStrategy(),
-				hook.getHookString());
-	}
-
-	public static By By(Strategy strategy, String hookString)
-			throws CandybeanException {
-		switch (strategy) {
-		case CSS:
-			return By.cssSelector(hookString);
-		case XPATH:
-			return By.xpath(hookString);
-		case ID:
-			return By.id(hookString);
-		case NAME:
-			return By.name(hookString);
-		case LINK:
-			return By.linkText(hookString);
-		case PLINK:
-			return By.partialLinkText(hookString);
-		case CLASS:
-			return By.className(hookString);
-		case TAG:
-			return By.tagName(hookString);
-		default:
-			throw new CandybeanException("Strategy type not recognized.");
-		}
+		return Hook.getBy(this.hook);
 	}
 }

--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverInterface.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverInterface.java
@@ -85,6 +85,7 @@ public abstract class WebDriverInterface extends AutomationInterface {
 	 */
 	@Override
 	public void start() throws CandybeanException {
+		// Set implicit wait and timeout parameters
 		long implicitWait = Long.parseLong(candybean.config.getValue("perf.implicit.wait.seconds"));
 		wd.manage().timeouts().implicitlyWait(implicitWait, TimeUnit.SECONDS);
 		if (System.getProperty("headless") == null
@@ -122,6 +123,16 @@ public abstract class WebDriverInterface extends AutomationInterface {
 	public void interact(String message) {
 		logger.info("Interaction via popup dialog with message: " + message);
 		JOptionPane.showInputDialog(message);
+	}
+
+	/**
+	 * Returns a WebDriverPause object for waiting on some condition
+	 * @return
+	 */
+	public WebDriverPause getPause() {
+		long timeoutS = Long.parseLong(candybean.config.getValue("perf.explicit.wait.seconds", "15"));
+		long timeoutMs = timeoutS * 1000;
+		return new WebDriverPause(wd, timeoutMs);
 	}
 	
 	/**
@@ -233,7 +244,7 @@ public abstract class WebDriverInterface extends AutomationInterface {
 	 */
 	public void focusFrame(int index) throws CandybeanException {
 		logger.info("Focusing to frame by index: " + index);
-		this.wd.switchTo().frame(index);
+		this.getPause().waitUntil(WaitConditions.frameToBeAvailableAndSwitchToIt(index));
 	}
 	
 	/**
@@ -243,7 +254,7 @@ public abstract class WebDriverInterface extends AutomationInterface {
 	 */
 	public void focusFrame(String nameOrId) throws CandybeanException {
 		logger.info("Focusing to frame by name or ID: " + nameOrId);
-		this.wd.switchTo().frame(nameOrId);
+		this.getPause().waitUntil(WaitConditions.frameToBeAvailableAndSwitchToIt(nameOrId));
 	}
 	
 	/**
@@ -253,7 +264,7 @@ public abstract class WebDriverInterface extends AutomationInterface {
 	 */
 	public void focusFrame(WebDriverElement wde) throws CandybeanException {
 		logger.info("Focusing to frame by element: " + wde.toString());
-		this.wd.switchTo().frame(wde.we);
+		this.getPause().waitUntil(WaitConditions.frameToBeAvailableAndSwitchToIt(wde));
 	}
 	
 	/**
@@ -423,7 +434,7 @@ public abstract class WebDriverInterface extends AutomationInterface {
 	 */
 	public List<WebDriverElement> getWebDriverElements(Hook hook) throws CandybeanException {
 		List<WebDriverElement> elements = new ArrayList<WebDriverElement>();
-		List<WebElement> wes = this.wd.findElements(WebDriverElement.By(hook.getHookStrategy(), hook.getHookString()));
+		List<WebElement> wes = this.wd.findElements(Hook.getBy(hook));
 		for (WebElement we : wes)
 			elements.add(new WebDriverElement(hook, 0, this.wd, we));
 		return elements;

--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverPause.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverPause.java
@@ -21,36 +21,121 @@
  */
 package com.sugarcrm.candybean.automation.webdriver;
 
-import org.openqa.selenium.support.ui.ExpectedConditions;
+import com.sugarcrm.candybean.automation.Candybean;
+import com.sugarcrm.candybean.automation.element.Hook;
+import org.openqa.selenium.WebDriver;
+
+import org.openqa.selenium.*;
+import org.openqa.selenium.support.ui.ExpectedCondition;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
-import com.sugarcrm.candybean.automation.element.Pause;
-import com.sugarcrm.candybean.automation.webdriver.WebDriverElement;
 import com.sugarcrm.candybean.exceptions.CandybeanException;
 
+import java.util.logging.Logger;
+
+import static java.lang.System.currentTimeMillis;
+
 /**
- * Utility class that provides several methods for an element to pause until an
- * action occurs.
+ * Utility class that provides several methods for an element to pause until a
+ * condition is satisfied
+ *
+ * @author Eric Tam
  */
-public class WebDriverPause extends Pause {
+public class WebDriverPause {
+	private WebDriver wd;
+	private long defaultTimeoutMs;
+	private static final long WD_POLLING_INTERVAL = 1000;
 
-	private WebDriverElement wde;
+	public Logger logger;
 
-	public WebDriverPause(WebDriverElement wde) {
-		this.wde = wde;
+	public WebDriverPause(WebDriver wd, long defaultTimeoutMs) {
+		this.wd = wd;
+		this.defaultTimeoutMs = defaultTimeoutMs;
+		this.logger = Logger.getLogger(Candybean.class.getSimpleName());
 	}
 
-	@Override
-	public WebDriverElement untilVisible(int timeoutMs) {
-		(new WebDriverWait(this.wde.wd, timeoutMs / 1000)).until(ExpectedConditions
-				.visibilityOf(this.wde.we));
-		return this.wde;
+	/**
+	 * Accepts any ExpectedCondition and poll under this condition is satisfied within timeout
+	 * @param timeoutMs	Timeout in Milliseconds
+	 * @param condition	The condition to poll
+	 * @return			Returning the object that is returned from ExpectedCondition when the condition is met
+	 * @throws CandybeanException
+	 */
+	public Object waitUntil(ExpectedCondition condition, long timeoutMs) throws CandybeanException {
+		long wdPollingInterval = WD_POLLING_INTERVAL;
+		if(timeoutMs <= WD_POLLING_INTERVAL) {
+			wdPollingInterval = timeoutMs;
+		}
+
+		// This is done by double-polling. WebDriverWait waits for wdPollingInterval amount of time.
+		// This is done repetitively until the time reaches timeoutMs.
+		final long startTime = currentTimeMillis();
+		long currentTime = 0;
+		CandybeanException toThrow = null;
+		Object toReturn = null;
+
+		while(currentTime <= timeoutMs) {
+			try {
+				logger.info(currentTime + " milliseconds have passed. Waiting until " + condition.toString() +
+						" is satisfied.");
+				toReturn = (new WebDriverWait(this.wd, wdPollingInterval / 1000)).until(condition);
+				toThrow = null;
+				break;
+			} catch (WebDriverException wdException) {
+				toThrow = new CandybeanException(wdException.toString());
+			}
+			currentTime = currentTimeMillis() - startTime;
+		}
+
+		if(toThrow != null) {
+			logger.severe("The timeout " + timeoutMs + " milliseconds have reached. Throwing Exception.");
+			throw toThrow;
+		}
+
+		return toReturn;
 	}
-	
-	public WebDriverElement untilTextPresent(String text, int timeout) 
-			throws CandybeanException {
-		(new WebDriverWait(this.wde.wd, timeout)).until(ExpectedConditions
-				.textToBePresentInElement(this.wde.getBy(), text));
-		return this.wde;
+
+	public Object waitUntil(ExpectedCondition<?> condition) throws CandybeanException {
+		return this.waitUntil(condition, defaultTimeoutMs);
+	}
+
+	/**
+	 * Provides a simple method to wait for visible as it is often used
+	 * @param hook
+	 * @param timeoutMs
+	 * @throws CandybeanException
+	 */
+	public WebDriverElement waitForVisible(Hook hook, long timeoutMs) throws CandybeanException {
+		return (WebDriverElement) this.waitUntil(WaitConditions.visible(hook), timeoutMs);
+	}
+
+	/**
+	 * Provides a simple method to wait for visible as it is often used
+	 * @param hook
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public WebDriverElement waitForVisible(Hook hook) throws CandybeanException {
+		return this.waitForVisible(hook, defaultTimeoutMs);
+	}
+
+	/**
+	 * Provides a simple method to wait for visible as it is often used
+	 * @param wde
+	 * @param timeoutMs
+	 * @throws CandybeanException
+	 */
+	public WebDriverElement waitForVisible(WebDriverElement wde, long timeoutMs) throws CandybeanException {
+		return (WebDriverElement) this.waitUntil(WaitConditions.visible(wde), timeoutMs);
+	}
+
+	/**
+	 * Provides a simple method to wait for visible as it is often used
+	 * @param wde
+	 * @return
+	 * @throws CandybeanException
+	 */
+	public WebDriverElement waitForVisible(WebDriverElement wde) throws CandybeanException {
+		return this.waitForVisible(wde, defaultTimeoutMs);
 	}
 }

--- a/src/test/java/com/sugarcrm/candybean/automation/webdriver/WebDriverElementSystemTest.java
+++ b/src/test/java/com/sugarcrm/candybean/automation/webdriver/WebDriverElementSystemTest.java
@@ -36,7 +36,6 @@ import org.junit.runner.RunWith;
 import com.sugarcrm.candybean.automation.AutomationInterface.Type;
 import com.sugarcrm.candybean.automation.Candybean;
 import com.sugarcrm.candybean.automation.AutomationInterfaceBuilder;
-import com.sugarcrm.candybean.automation.webdriver.WebDriverElement;
 import com.sugarcrm.candybean.automation.element.Hook;
 import com.sugarcrm.candybean.automation.element.Hook.Strategy;
 import com.sugarcrm.candybean.exceptions.CandybeanException;
@@ -77,21 +76,19 @@ public class WebDriverElementSystemTest {
 	
 	@Test
 	public void getElementTest() throws Exception {
-		String expH2 = "san francisco";
+		String logoText = "craigslist";
 		iface.go("http://sfbay.craigslist.org/");
-		WebDriverElement header = iface.getWebDriverElement(Strategy.ID, "topban");
-		((WebDriverElement) header.getElement(new Hook(Strategy.TAG, "a"), 1)).click();
-		header = iface.getWebDriverElement(Strategy.ID, "topban");
-		WebDriverElement h2Control = ((WebDriverElement) header.getElement(new Hook(Strategy.TAG, "h2"), 0));
-		String actH2 = h2Control.getText().trim();
-		Assert.assertEquals(expH2, actH2);
+		WebDriverElement div = iface.getWebDriverElement(Strategy.ID, "logo");
+		WebDriverElement logoElement = ((WebDriverElement) div.getElement(new Hook(Strategy.TAG, "a"), 0));
+		String actLogo = logoElement.getText().trim();
+		Assert.assertEquals(logoText, actLogo);
 	}
 
 	@Test
 	public void getElementsTest() throws Exception {
 		iface.go("http://sfbay.craigslist.org/");
 		List<WebDriverElement> elements = iface.getWebDriverElements(Strategy.CLASS,"ban");
-		Assert.assertEquals(elements.size(),15);
+		Assert.assertEquals(elements.size(),14);
 	}
 
 	@Test
@@ -182,7 +179,7 @@ public class WebDriverElementSystemTest {
 		iface.pause(timeout);
 		iface.getWebDriverElement(Strategy.XPATH, "//*[@id=\"test\"]/p[1]/button[1]").click();
 		startTime = System.currentTimeMillis();
-		textControl.pause.untilVisible(timeout);
+		iface.getPause().waitForVisible(textControl, 10000);
 		endTime = System.currentTimeMillis();
 		Assert.assertTrue((endTime - startTime) / Long.parseLong("1000") < (long)timeout);
 	}
@@ -197,7 +194,7 @@ public class WebDriverElementSystemTest {
 		showAlertButton.click();
 		iface.pause(500);
 		WebDriverElement delayAlert = iface.getWebDriverElement(new Hook(Strategy.CSS, ".hentry .quick-alert"));
-		delayAlert.pause.untilVisible((int)timeoutMilliSec);
+		iface.getPause().waitForVisible(delayAlert, (int)timeoutMilliSec);
 		Assert.assertTrue(delayAlert.isDisplayed());
 		
 		/* 
@@ -210,6 +207,18 @@ public class WebDriverElementSystemTest {
 //		Assert.assertFalse(delayAlert.isDisplayed());
 //		thrown.expect(TimeoutException.class);
 //		delayAlert.pause.untilVisible((int)timeoutMilliSec);
+	}
+
+	@Test
+	public void pauseUntilClickableTest() throws Exception {
+		String url = "http://sfbay.craigslist.org/";
+		iface.go(url);
+
+		String sfcLi = "#topban .sublinks li:first-child";
+		Hook sfcLiButton = new Hook(Strategy.CSS, sfcLi + " a");
+		iface.getPause().waitUntil(WaitConditions.clickable(sfcLiButton));
+		iface.getWebDriverElement(sfcLiButton).click();
+		Assert.assertEquals(iface.getURL(), url + "sfc/");
 	}
 
 	@Test


### PR DESCRIPTION
This PR addresses explicit waits in candybean.

 `WebDriverPause` is updated with a generic wait method `waitUntil()` that polls until a condition (that is passed as a parameter) is satisfied. The condition can be any `ExpectedCondition`. A comprehensive list that is relevant to candybean is in `WaitCondition`. Some conditions are already built in by Selenium and some are custom conditions only for candybean. The default timeout value can be obtained from candybean.config!
