### PR TITLE
Changed Candybean select all and clear methods

### DIFF
--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverElement.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverElement.java
@@ -32,6 +32,7 @@ import com.sugarcrm.candybean.automation.element.Location;
 import com.sugarcrm.candybean.automation.element.Hook.Strategy;
 import com.sugarcrm.candybean.exceptions.CandybeanException;
 
+
 /**
  * Represents an identifiable (via {@link By}) element or element on a page that
  * can be interacted with. A {@link WebDriverElement} object should be used to
@@ -353,20 +354,53 @@ public class WebDriverElement extends Element {
 	}
 
 	/**
-	 * Selects all text in this element if it is a textfield.  Note that this method does not
-	 * currently support textareas or any type of element apart from a textfield.  It clicks on the
-	 * element, so links will be activated, radio buttons will be selected, drop boxes will be
-	 * opened, etc.  Use of this method on any non-textfield element is not currently supported.
+	 * Selects all text in and focuses on a Javascript HTMLInputElement.
+	 * Selects only from input fields, and will not currently work on
+	 * textAreas (CB-260) but support is planned
+	 *
+	 * @throws CandybeanException If used on a non INPUT element
 	 */
-	public void selectAll() {
-		we.click();
-		we.sendKeys(Keys.END,Keys.chord(Keys.SHIFT,Keys.HOME));
+	public void selectAll() throws CandybeanException {
+		String tag = we.getTagName();
+		// The Javascript select() method is INPUT specific, throw if used
+		// on a non-INPUT tag
+		if (!"input".equals(tag)) {
+			throw new CandybeanException("Cannot select text of a non-" +
+					"INPUT element. Actual element was of tag: " + tag);
+		}
+		executeJavascript("arguments[0].select()");
+	}
+
+	/**
+	 * Clears an element. If the element is an "input" element, clear
+	 * it by selecting all the text and pressing back space to avoid
+	 * triggering an onChange event. We don't want to trigger the onChange
+	 * event while clearing a textfield as doing so may interfere with the
+	 * following set call
+	 *
+	 * If the field is not an "input" element, use Selenium's clear method
+	 * instead
+	 *
+	 * Also focuses the cleared element
+	 */
+	public void clear() throws CandybeanException {
+		String tag = we.getTagName();
+		// Theoretically, the .select() call in selectAll should focus the element
+		// according to https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/select
+		// However, this seems to have issues in iframes, so we call focus regardless
+		executeJavascript("arguments[0].focus()");
+		if ("input".equals(tag)) {
+			selectAll();
+			we.sendKeys(Keys.BACK_SPACE);
+		} else {
+			we.clear();
+		}
 	}
 
 	/**
 	 * Clear the element and send a string to it.
 	 * 
-	 * @param   input   string to send
+	 * @param	input	The string to send
 	 */
 	public void sendString(String input) throws CandybeanException {
 		sendString(input, false);
@@ -377,17 +411,14 @@ public class WebDriverElement extends Element {
 	 * 
 	 * @param   input   string to send
 	 * @param   append  if append is false, the element will be cleared first
-	 * @throws  CandybeanException
+	 * @throws CandybeanException
 	 */
 	public void sendString(String input, boolean append) throws CandybeanException {
-		logger.info((append ? "Clearing field and s" : "S") + "ending string: " + input +
-			" to element: " + toString());
-
-		if(!append) {
-			selectAll();
-			we.sendKeys(Keys.DELETE);
+		logger.info((append ? "Appending" : "Clearing field and sending") + " text: \"" + input +
+				"\" to element: " + toString());
+		if (!append) {
+			clear();
 		}
-
 		we.sendKeys(input);
 	}
 


### PR DESCRIPTION
SelectAll()
- WebDriverElement.selectAll now selects all text in a multi line
  textfield

Clear() detects type of element

- Made WebDriverElement.clear() detect what type of element it is
  clearing and if it is a text element, uses a method that does not
  trigger an onChange event

Test results here:
http://ci/view/Voodoo/job/Voodoo_CB_Custom_Full_Tests/lastCompletedBuild/testReport/
vs
http://ci/job/7700beta6_Voodoo_Tests/15/

433 Failures to Production's 446