### PR TITLE
CB-241: Timeouts and Retries for Candybean

### DIFF
--- a/candybean.config
+++ b/candybean.config
@@ -62,13 +62,10 @@ java.util.logging.SimpleFormatter.format = [%1$tH:%1$tM:%1$tS:%1$tL] %4$s: %2$s 
 
 # Runner settings
 
-# The number of times to retry a failing test
 runner.retryCount = 1
-# The global timeout of a test run before failing (0 is no timeout)
 runner.timeout = 1500
-runner.afterTimeout = 1500
-# If a test fails because of runner.timeout, rerun the test if true
-runner.rerunIfTimedOut= true
+runner.cleanupTimeout = 1500
+runner.rerunIfTimedOut= false
 runner.runBeforeIfTimedOut = true
 runner.runAfterIfTimedOut = true
 

--- a/candybean.config
+++ b/candybean.config
@@ -60,6 +60,18 @@ java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 # Logging format
 java.util.logging.SimpleFormatter.format = [%1$tH:%1$tM:%1$tS:%1$tL] %4$s: %2$s %5$s%6$s%n
 
+# Runner settings
+
+# The number of times to retry a failing test
+runner.retryCount = 1
+# The global timeout of a test run before failing (0 is no timeout)
+runner.timeout = 1500
+runner.afterTimeout = 1500
+# If a test fails because of runner.timeout, rerun the test if true
+runner.rerunIfTimedOut= true
+runner.runBeforeIfTimedOut = true
+runner.runAfterIfTimedOut = true
+
 # Monte Media Library Recorder Settings
 video.format=video/quicktime
 video.format.frameRate=15

--- a/pom.xml
+++ b/pom.xml
@@ -245,7 +245,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.11</version>
+			<version>4.12</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/com/sugarcrm/candybean/automation/Candybean.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/Candybean.java
@@ -58,6 +58,8 @@ public final class Candybean {
 			ROOT_DIR + File.separator + "candybean.config",
 			ROOT_DIR + File.separator + "src" + File.separator + "test" +
 					File.separator + "resources" + File.separator + "candybean.config",
+			// Using the "Voodoo" name is deprecated and Candybean should be used instead
+			// https://sugarcrm.atlassian.net/browse/CB-270
 			ROOT_DIR + File.separator + "src" + File.separator + "test" +
 					File.separator + "resources" + File.separator + "voodoo.properties"
 			);

--- a/src/main/java/com/sugarcrm/candybean/automation/Candybean.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/Candybean.java
@@ -23,8 +23,10 @@ package com.sugarcrm.candybean.automation;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.*;
 import java.util.logging.LogManager;
 import java.util.logging.Logger;
+
 import com.sugarcrm.candybean.configuration.Configuration;
 import com.sugarcrm.candybean.exceptions.CandybeanException;
 import com.sugarcrm.candybean.utilities.CandybeanLogger;
@@ -52,7 +54,13 @@ public final class Candybean {
 	/**
 	 * The default configuration file name to instantiate candybean.
 	 */
-	public static final String DEFAULT_CONFIG_FILE = ROOT_DIR + File.separator + "candybean.config";
+	public static final List<String> DEFAULT_CONFIG_FILES = Arrays.asList(
+			ROOT_DIR + File.separator + "candybean.config",
+			ROOT_DIR + File.separator + "src" + File.separator + "test" +
+					File.separator + "resources" + File.separator + "candybean.config",
+			ROOT_DIR + File.separator + "src" + File.separator + "test" +
+					File.separator + "resources" + File.separator + "voodoo.properties"
+			);
 
 	/**
 	 * {@link Configuration} object created by loading the candybean
@@ -187,11 +195,22 @@ public final class Candybean {
 	public AutomationInterface getInterface() throws Exception {
 		throw new Exception("There are no non-webdriver automation interfaces currently defined.");
 	}
-	
+
+	public static String getDefaultConfigFile() throws CandybeanException{
+		final String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY);
+		if (candybeanConfigStr != null) {
+			return candybeanConfigStr;
+		}
+		for (String f: Candybean.DEFAULT_CONFIG_FILES) {
+			if (new File(f).exists()) {
+				return f;
+			}
+		}
+		throw new CandybeanException("Could not find appropriate config file");
+	}
 	private static Configuration getDefaultConfiguration() throws CandybeanException {
 		try {
-			String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.DEFAULT_CONFIG_FILE);
-			return new Configuration(new File(Utils.adjustPath(candybeanConfigStr)));
+			return new Configuration(new File(Utils.adjustPath(getDefaultConfigFile())));
 		} catch (IOException ioe) {
 			throw new CandybeanException(ioe);
 		}

--- a/src/main/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunner.java
+++ b/src/main/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunner.java
@@ -14,15 +14,16 @@ import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.InitializationError;
 import org.junit.runners.model.Statement;
+
 import java.util.concurrent.*;
 
 /**
  * CandybeanRunner is a test runner designed to give more control over the test runs.
  * It provides features that while currently available in JUnit, are implemented in a
  * slightly different manner.
- *
+ * <p>
  * To use the runner, annotate your tests with @RunWith(CandybeanRunner.class)
- *
+ * <p>
  * <b>Test Retries</b>
  * Set the value "runner.retryCount = x" in candybean.config where x is the maximum
  * number of times to retry a test if the first run fails (default 0). If any of the
@@ -31,37 +32,39 @@ import java.util.concurrent.*;
  * well with external reporting tools such as Allure. Allure currently has a PR in
  * to fix that in which retries may become unnecessary.
  * <a href=https://github.com/allure-framework/allure-core/issues/611>Link</a>
- *
+ * <p>
  * <b>Test Timeouts</b>
- * Set the value "runner.timeout = x"  in candybean.conig where x is the maximum time in
+ * Set the value "runner.timeout = x"  in candybean.config where x is the maximum time in
  * milliseconds that a test (including its @Before and @After methods) should run before
  * being killed. This setting allows a \@Test('timeout=xxx') like functionality to be set
- * on a class level rather than on a per test level i.e. if test fails, its \@After
+ * on a class level rather than on a per test level i.e. if the test fails, its \@After
  * method will still be ran, unlike setting a timeout @Rule which will hard kill tests
  * without running \@After.
  * Additionally, the timeout applies to the \@Before, \@Test, and \@After methods together,
- *
+ * <p>
  * The precise order of actions which are run is @Before -> @Test -> @After. If the timeout
  * occurs during any of the methods, the test will be killed, and the runner will attempt to
- * run @After, even if @After had already begun. If the second @After fails, the runner will
- * simply continue on, notifying that the test failed in @After.
- *
+ * run @Before and @After to clean up the environment, depending on candybean.config. If
+ * the cleaning up fails, the runner will simply continue on, notifying that the test failed.
+ * <p>
  * <b>Additional Settings</b>
- * runner.rerunIfTimedOut = [true|false] If false, do not rerun if a test fails due to timeout
- * runner.afterTimeout = xxx The max timeout @After will run for. (Defaults to runner.timeout)
- * runner.afterIfTimedOut = xxx The max timeout @After will run for. (Defaults to runner.timeout)
- *
+ * runner.rerunIfTimedOut     = [true|false] If false, do not rerun if a test fails due to timeout
+ * runner.cleanupTimeout      = xxx The max timeout in milliseconds the runner will attempt to
+ * clean up after timing out (Defaults to runner.timeout)
+ * runner.runBeforeIfTimedOut = [true|false] If true, run the @Before method on timeout
+ * runner.runAfterIfTimedOut  = [true|false] If true, run the @After method on timeout
  */
 public class CandybeanRunner extends BlockJUnit4ClassRunner {
 
 	protected final Candybean candybean = Candybean.getInstance();
-	private final int retryCount = Integer.parseInt(candybean.config.getValue("runner.retryCount", "0"));
-	private final int timeout = Integer.parseInt(candybean.config.getValue("runner.timeout", "0"));
-	private final int afterTimeout= Integer.parseInt(
-			candybean.config.getValue("runner.afterTimeout", String.valueOf(timeout)));
-	private final boolean rerunIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.rerunIfTimedOut", "false"));
-	private final boolean runBeforeIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.runBeforeIfTimedOut", "true"));
-	private final boolean runAfterIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.runAfterIfTimedOut", "true"));
+	protected final int retryCount = Integer.parseInt(candybean.config.getValue("runner.retryCount", "0"));
+	protected final int timeout = Integer.parseInt(candybean.config.getValue("runner.timeout", "0"));
+	protected final int cleanupTimeout = Integer.parseInt(
+			candybean.config.getValue("runner.cleanupTimeout", String.valueOf(timeout)));
+	protected final boolean rerunIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.rerunIfTimedOut", "false"));
+	protected final boolean runBeforeIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.runBeforeIfTimedOut", "true"));
+	protected final boolean runAfterIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.runAfterIfTimedOut", "true"));
+	final boolean INTERRUPT = true;
 
 	/**
 	 * Creates a BlockJUnit4ClassRunner to run klass
@@ -83,6 +86,8 @@ public class CandybeanRunner extends BlockJUnit4ClassRunner {
 		 *  Runs @BeforeClass
 		 *  Runs All children tests with runChild
 		 *  Runs @AfterClass
+		 *
+		 *  If the test fails, it notifies the test runner
 		 */
 		final Statement statement = classBlock(notifier);
 		try {
@@ -96,7 +101,6 @@ public class CandybeanRunner extends BlockJUnit4ClassRunner {
 
 	@Override
 	protected void runChild(final FrameworkMethod method, RunNotifier notifier) {
-		final boolean INTERRUPT = true;
 		final Description description = describeChild(method);
 
 		if (method.getAnnotation(Ignore.class) != null) {
@@ -107,11 +111,12 @@ public class CandybeanRunner extends BlockJUnit4ClassRunner {
 		final EachTestNotifier eachTestNotifier = new EachTestNotifier(notifier, description);
 		final Statement statement = methodBlock(method);
 
+		// Construct a callable to run a single test
 		final Callable<Void> runTest = new Callable<Void>() {
 			public Void call() throws Exception {
 				try {
 					statement.evaluate();
-				} catch (Error|Exception e) {
+				} catch (Error | Exception e) {
 					throw e;
 				} catch (Throwable e) {
 					throw new Exception(e);
@@ -124,86 +129,31 @@ public class CandybeanRunner extends BlockJUnit4ClassRunner {
 		Throwable throwable;
 		int attempts = 0;
 		do {
-			throwable= null;
+			throwable = null;
 			final ExecutorService executorService = Executors.newCachedThreadPool();
 			Future task = executorService.submit(runTest);
 			try {
 				// Create task to run the test, and attempt to retrieve it within
-				// the time limit
+				// the time limit, else throw a timeout exception
 				task.get(timeout, TimeUnit.MILLISECONDS);
 			} catch (TimeoutException te) {
 				throwable = new TimeoutException(description + " exceeded allocated runtime of " + timeout + "ms");
-				candybean.log.severe( description + " exceeded allocated runtime of " + timeout + "ms, killing now");
+				candybean.log.severe(description + " exceeded allocated runtime of " + timeout + "ms, killing now");
+
+				// Interupt the task and shutdown the task executor
 				task.cancel(INTERRUPT);
 				executorService.shutdownNow();
-				// If we catch a timeout exception, attempt to run @After, if the enabled, regardless of state
+				// If we catch a timeout exception, attempt to run @Before and @After, if enabled
 				if (runAfterIfTimedOut || runBeforeIfTimedOut) {
-					try {
-						final ExecutorService innerExecutorService = Executors.newCachedThreadPool();
-						final Object test = new ReflectiveCallable() {
-							@Override
-							protected Object runReflectiveCall() throws Throwable {
-								return createTest();
-							}
-						}.run();
-						final Callable<Void> runAfter = new Callable<Void>() {
-							public Void call() throws Exception {
-								try {
-									if (runBeforeIfTimedOut && runAfterIfTimedOut) {
-										withBefores(method, test,
-											withAfters(method, test, new Statement() {
-											@Override
-											public void evaluate() throws Throwable {
-											}
-										})).evaluate();
-									}
-									else if (runBeforeIfTimedOut) {
-										withBefores(method, test, new Statement() {
-											@Override
-											public void evaluate() throws Throwable {
-											}
-										}).evaluate();
-									}
-									else if (runAfterIfTimedOut) {
-										withAfters(method, test, new Statement() {
-											@Override
-											public void evaluate() throws Throwable {
-											}
-										}).evaluate();
-									}
-								} catch (Error | Exception e) {
-									throw e;
-								} catch (Throwable t) {
-									throw new Exception(t);
-								}
-								return null;
-							}
-						};
-						Future afterTask = innerExecutorService.submit(runAfter);
-						try {
-							afterTask.get(afterTimeout, TimeUnit.MILLISECONDS);
-						} catch (ExecutionException e) {
-							afterTask.cancel(INTERRUPT);
-							continue;
-						} catch (TimeoutException e) {
-							candybean.log.severe(getDescription() + "' @After method exceeded allocated runtime of "
-									+ afterTimeout + "ms, killing now");
-							afterTask.cancel(INTERRUPT);
-							continue;
-						} finally {
-							innerExecutorService.shutdownNow();
-						}
-					} catch (Throwable t) {
-						throwable = new Exception(t);
-					}
+					cleanUpState(method);
 				}
 				if (!rerunIfTimedOut) {
 					break;
 				}
 			} catch (ExecutionException e) {
+				// If the test failed, unwrap the ExecutionException
 				throwable = e.getCause();
-			}
-			catch (AssumptionViolatedException|InterruptedException t) {
+			} catch (AssumptionViolatedException | InterruptedException t) {
 				throwable = t;
 			}
 			if (throwable != null && attempts != retryCount) {
@@ -215,5 +165,74 @@ public class CandybeanRunner extends BlockJUnit4ClassRunner {
 			eachTestNotifier.addFailure(throwable);
 		}
 		eachTestNotifier.fireTestFinished();
+	}
+
+	/**
+	 * Attempts to cleanup the testing environment using the Afters and Befores of method
+	 *
+	 * @param method The method to use to cleanup state
+	 */
+	protected void cleanUpState(final FrameworkMethod method) {
+		Future cleanupTask = null;
+		final ExecutorService executorService = Executors.newCachedThreadPool();
+		try {
+			// Construct a new empty test
+			final Object test = new ReflectiveCallable() {
+				@Override
+				protected Object runReflectiveCall() throws Throwable {
+					return createTest();
+				}
+			}.run();
+			// Attach the befores and afters to the empty test
+			final Callable<Void> runAfter = new Callable<Void>() {
+				public Void call() throws Exception {
+					try {
+						if (runBeforeIfTimedOut && runAfterIfTimedOut) {
+							withBefores(method, test,
+									withAfters(method, test, new Statement() {
+										@Override
+										public void evaluate() throws Throwable {
+										}
+									})).evaluate();
+						} else if (runBeforeIfTimedOut) {
+							withBefores(method, test, new Statement() {
+								@Override
+								public void evaluate() throws Throwable {
+								}
+							}).evaluate();
+						} else {
+							withAfters(method, test, new Statement() {
+								@Override
+								public void evaluate() throws Throwable {
+								}
+							}).evaluate();
+						}
+					} catch (Error | Exception e) {
+						throw e;
+					} catch (Throwable t) {
+						throw new Exception(t);
+					}
+					return null;
+				}
+			};
+			cleanupTask = executorService.submit(runAfter);
+			cleanupTask.get(cleanupTimeout, TimeUnit.MILLISECONDS);
+		} catch (ExecutionException e) {
+			// If cleaning up failed, log a warning, but continue on, we use the original error to
+			// notify the test runner, not this one
+			candybean.log.warning("Cleaning up" + getDescription() + "failed with " + e.getCause());
+		} catch (TimeoutException e) {
+			// Similar to if cleaning up failed, we alert if the clean up timed out, but continue on
+			// after killing the cleanup task
+			candybean.log.warning(getDescription() + "' @After method exceeded allocated runtime of "
+					+ cleanupTimeout + "ms, killing now");
+			if (cleanupTask != null) {
+				cleanupTask.cancel(INTERRUPT);
+			}
+		} catch (Throwable t) {
+			candybean.log.warning("Cleaning up" + getDescription() + "failed with " + t);
+		} finally {
+			executorService.shutdownNow();
+		}
 	}
 }

--- a/src/main/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunner.java
+++ b/src/main/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunner.java
@@ -1,0 +1,219 @@
+package com.sugarcrm.candybean.candybeanRunner;
+
+import com.sugarcrm.candybean.automation.Candybean;
+import com.sugarcrm.candybean.exceptions.CandybeanException;
+import org.junit.Ignore;
+import org.junit.internal.AssumptionViolatedException;
+import org.junit.internal.runners.model.EachTestNotifier;
+import org.junit.internal.runners.model.ReflectiveCallable;
+import org.junit.runner.Description;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunNotifier;
+import org.junit.runner.notification.StoppedByUserException;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.Statement;
+import java.util.concurrent.*;
+
+/**
+ * CandybeanRunner is a test runner designed to give more control over the test runs.
+ * It provides features that while currently available in JUnit, are implemented in a
+ * slightly different manner.
+ *
+ * To use the runner, annotate your tests with @RunWith(CandybeanRunner.class)
+ *
+ * <b>Test Retries</b>
+ * Set the value "runner.retryCount = x" in candybean.config where x is the maximum
+ * number of times to retry a test if the first run fails (default 0). If any of the
+ * runs pass, the test is marked as a pass. This differs from setting
+ * -DrerunFailingTestsCount as that will mark tests as a flake, which does not play
+ * well with external reporting tools such as Allure. Allure currently has a PR in
+ * to fix that in which retries may become unnecessary.
+ * <a href=https://github.com/allure-framework/allure-core/issues/611>Link</a>
+ *
+ * <b>Test Timeouts</b>
+ * Set the value "runner.timeout = x"  in candybean.conig where x is the maximum time in
+ * milliseconds that a test (including its @Before and @After methods) should run before
+ * being killed. This setting allows a \@Test('timeout=xxx') like functionality to be set
+ * on a class level rather than on a per test level i.e. if test fails, its \@After
+ * method will still be ran, unlike setting a timeout @Rule which will hard kill tests
+ * without running \@After.
+ * Additionally, the timeout applies to the \@Before, \@Test, and \@After methods together,
+ *
+ * The precise order of actions which are run is @Before -> @Test -> @After. If the timeout
+ * occurs during any of the methods, the test will be killed, and the runner will attempt to
+ * run @After, even if @After had already begun. If the second @After fails, the runner will
+ * simply continue on, notifying that the test failed in @After.
+ *
+ * <b>Additional Settings</b>
+ * runner.rerunIfTimedOut = [true|false] If false, do not rerun if a test fails due to timeout
+ * runner.afterTimeout = xxx The max timeout @After will run for. (Defaults to runner.timeout)
+ * runner.afterIfTimedOut = xxx The max timeout @After will run for. (Defaults to runner.timeout)
+ *
+ */
+public class CandybeanRunner extends BlockJUnit4ClassRunner {
+
+	protected final Candybean candybean = Candybean.getInstance();
+	private final int retryCount = Integer.parseInt(candybean.config.getValue("runner.retryCount", "0"));
+	private final int timeout = Integer.parseInt(candybean.config.getValue("runner.timeout", "0"));
+	private final int afterTimeout= Integer.parseInt(
+			candybean.config.getValue("runner.afterTimeout", String.valueOf(timeout)));
+	private final boolean rerunIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.rerunIfTimedOut", "false"));
+	private final boolean runBeforeIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.runBeforeIfTimedOut", "true"));
+	private final boolean runAfterIfTimedOut = Boolean.parseBoolean(candybean.config.getValue("runner.runAfterIfTimedOut", "true"));
+
+	/**
+	 * Creates a BlockJUnit4ClassRunner to run klass
+	 *
+	 * @param klass The class to initialize
+	 * @throws InitializationError
+	 * @throws CandybeanException
+	 */
+	public CandybeanRunner(Class<?> klass) throws InitializationError, CandybeanException {
+		super(klass);
+	}
+
+	@Override
+	/**
+	 * @{inheritDoc}
+	 */
+	public void run(final RunNotifier notifier) {
+		/* Construct statement that when evaluated:
+		 *  Runs @BeforeClass
+		 *  Runs All children tests with runChild
+		 *  Runs @AfterClass
+		 */
+		final Statement statement = classBlock(notifier);
+		try {
+			statement.evaluate();
+		} catch (StoppedByUserException e) {
+			throw e;
+		} catch (Throwable e) {
+			notifier.fireTestFailure(new Failure(getDescription(), e));
+		}
+	}
+
+	@Override
+	protected void runChild(final FrameworkMethod method, RunNotifier notifier) {
+		final boolean INTERRUPT = true;
+		final Description description = describeChild(method);
+
+		if (method.getAnnotation(Ignore.class) != null) {
+			notifier.fireTestIgnored(description);
+			return;
+		}
+
+		final EachTestNotifier eachTestNotifier = new EachTestNotifier(notifier, description);
+		final Statement statement = methodBlock(method);
+
+		final Callable<Void> runTest = new Callable<Void>() {
+			public Void call() throws Exception {
+				try {
+					statement.evaluate();
+				} catch (Error|Exception e) {
+					throw e;
+				} catch (Throwable e) {
+					throw new Exception(e);
+				}
+				return null;
+			}
+		};
+		eachTestNotifier.fireTestStarted();
+
+		Throwable throwable;
+		int attempts = 0;
+		do {
+			throwable= null;
+			final ExecutorService executorService = Executors.newCachedThreadPool();
+			Future task = executorService.submit(runTest);
+			try {
+				// Create task to run the test, and attempt to retrieve it within
+				// the time limit
+				task.get(timeout, TimeUnit.MILLISECONDS);
+			} catch (TimeoutException te) {
+				throwable = new TimeoutException(description + " exceeded allocated runtime of " + timeout + "ms");
+				candybean.log.severe( description + " exceeded allocated runtime of " + timeout + "ms, killing now");
+				task.cancel(INTERRUPT);
+				executorService.shutdownNow();
+				// If we catch a timeout exception, attempt to run @After, if the enabled, regardless of state
+				if (runAfterIfTimedOut || runBeforeIfTimedOut) {
+					try {
+						final ExecutorService innerExecutorService = Executors.newCachedThreadPool();
+						final Object test = new ReflectiveCallable() {
+							@Override
+							protected Object runReflectiveCall() throws Throwable {
+								return createTest();
+							}
+						}.run();
+						final Callable<Void> runAfter = new Callable<Void>() {
+							public Void call() throws Exception {
+								try {
+									if (runBeforeIfTimedOut && runAfterIfTimedOut) {
+										withBefores(method, test,
+											withAfters(method, test, new Statement() {
+											@Override
+											public void evaluate() throws Throwable {
+											}
+										})).evaluate();
+									}
+									else if (runBeforeIfTimedOut) {
+										withBefores(method, test, new Statement() {
+											@Override
+											public void evaluate() throws Throwable {
+											}
+										}).evaluate();
+									}
+									else if (runAfterIfTimedOut) {
+										withAfters(method, test, new Statement() {
+											@Override
+											public void evaluate() throws Throwable {
+											}
+										}).evaluate();
+									}
+								} catch (Error | Exception e) {
+									throw e;
+								} catch (Throwable t) {
+									throw new Exception(t);
+								}
+								return null;
+							}
+						};
+						Future afterTask = innerExecutorService.submit(runAfter);
+						try {
+							afterTask.get(afterTimeout, TimeUnit.MILLISECONDS);
+						} catch (ExecutionException e) {
+							afterTask.cancel(INTERRUPT);
+							continue;
+						} catch (TimeoutException e) {
+							candybean.log.severe(getDescription() + "' @After method exceeded allocated runtime of "
+									+ afterTimeout + "ms, killing now");
+							afterTask.cancel(INTERRUPT);
+							continue;
+						} finally {
+							innerExecutorService.shutdownNow();
+						}
+					} catch (Throwable t) {
+						throwable = new Exception(t);
+					}
+				}
+				if (!rerunIfTimedOut) {
+					break;
+				}
+			} catch (ExecutionException e) {
+				throwable = e.getCause();
+			}
+			catch (AssumptionViolatedException|InterruptedException t) {
+				throwable = t;
+			}
+			if (throwable != null && attempts != retryCount) {
+				candybean.getLogger().warning("Caught \"" + throwable +
+						"\" while running " + description + ", but have not yet exceeded retries. Retrying test...");
+			}
+		} while (throwable != null && attempts++ < retryCount);
+		if (throwable != null) {
+			eachTestNotifier.addFailure(throwable);
+		}
+		eachTestNotifier.fireTestFinished();
+	}
+}

--- a/src/main/java/com/sugarcrm/candybean/runner/TestRecorder.java
+++ b/src/main/java/com/sugarcrm/candybean/runner/TestRecorder.java
@@ -125,7 +125,7 @@ public class TestRecorder extends RunListener {
 		super();
 		logger = Logger.getLogger(Candybean.class.getSimpleName());
 		this.context = JAXBContext.newInstance(FailedTests.class);
-		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.DEFAULT_CONFIG_FILE);
+		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.getDefaultConfigFile());
 		this.config = new Configuration(new File(candybeanConfigStr));
 		this.xmlFile = createFile(config.getValue("testResultsXMLPath", FAILED_TEST_RESULTS_XML), false);
 	}

--- a/src/test/java/com/sugarcrm/candybean/automation/CandybeanUnitTest.java
+++ b/src/test/java/com/sugarcrm/candybean/automation/CandybeanUnitTest.java
@@ -33,7 +33,7 @@ public class CandybeanUnitTest {
 
 	@Test
 	public void testCandybeanLog() throws Exception {
-		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.DEFAULT_CONFIG_FILE);
+		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.getDefaultConfigFile());
 		Configuration candybeanConfig = new Configuration(new File(Utils.adjustPath(candybeanConfigStr)));
 		Candybean candybean = Candybean.getInstance(candybeanConfig);
 		assert(candybean != null);

--- a/src/test/java/com/sugarcrm/candybean/automation/control/Adhoc.java
+++ b/src/test/java/com/sugarcrm/candybean/automation/control/Adhoc.java
@@ -55,7 +55,7 @@ public class Adhoc {
 
 	@BeforeClass
 	public static void first() throws Exception {
-		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.DEFAULT_CONFIG_FILE);
+		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.getDefaultConfigFile());
 		Configuration candybeanConfig = new Configuration(new File(Utils.adjustPath(candybeanConfigStr)));
 		candybean = Candybean.getInstance(candybeanConfig);
 		iface = candybean.getAIB(Adhoc.class).build();

--- a/src/test/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunnerSystemTest.java
+++ b/src/test/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunnerSystemTest.java
@@ -6,10 +6,14 @@ import org.junit.runner.RunWith;
 
 import java.io.*;
 
+/**
+ * A series of test intended to test some of the expected function
+ * Since there doesn't appear to be a good way to test a runner, these
+ * tests certainly are not conclusive.
+ */
 @RunWith(CandybeanRunner.class)
 public class CandybeanRunnerSystemTest {
 	static String filename = "./candybeanTest.txt";
-	String testName;
 
 	@BeforeClass
 	static public void createFile() {
@@ -46,15 +50,17 @@ public class CandybeanRunnerSystemTest {
 
 	@Before
 	public void before() throws InterruptedException {
-		testName = getClass().getSimpleName();
-		System.err.println("In Before of " + testName);
 	}
 
 	@After
 	public void after() throws InterruptedException {
-		System.err.println("In After of " + testName);
 	}
 
+	/**
+	 * Increments a number in a file until the test passes
+	 * Note: Ensure that retries is set to at least 1
+	 * when running this test
+	 */
 	@Test
 	public void testCountTest() {
 		File f = new File(filename);
@@ -72,14 +78,18 @@ public class CandybeanRunnerSystemTest {
 
 	@Test
 	public void testTimeoutSuccess() throws InterruptedException {
-		System.err.println("In Tests");
 		Thread.sleep(500);
 	}
 
-	@Ignore("This test used to test timing out, it is expected to fail")
+	/**
+	 * This test is intended to fail, however, since it is killed by the runner, not
+	 * the test itself, it can't use an expected exception to run properly
+	 *
+	 * @throws InterruptedException
+	 */
+	@Ignore("This test is used to test timing out, it is expected to fail")
 	@Test
 	public void testTimeoutFail() throws InterruptedException {
-		System.err.println("In Tests");
 		Thread.sleep(2000);
 	}
 

--- a/src/test/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunnerSystemTest.java
+++ b/src/test/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunnerSystemTest.java
@@ -1,0 +1,92 @@
+package com.sugarcrm.candybean.candybeanRunner;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.*;
+import org.junit.runner.RunWith;
+
+import java.io.*;
+
+@RunWith(CandybeanRunner.class)
+public class CandybeanRunnerSystemTest {
+	static String filename = "./candybeanTest.txt";
+	String testName;
+
+	@BeforeClass
+	static public void createFile() {
+		File f = new File(filename);
+		if (f.exists()) {
+			if (!f.delete()) {
+				Assert.fail("Could not delete external resource " + filename);
+			}
+		} else {
+			try {
+				if (!f.createNewFile()) {
+					Assert.fail("Could not create external resource " + filename);
+				}
+			} catch (IOException e) {
+				Assert.fail("Could not create external resource " + filename);
+			}
+		}
+		try {
+			FileUtils.writeStringToFile(f, "0");
+		} catch (IOException e) {
+			Assert.fail("Could not write to file: " + filename);
+		}
+	}
+
+	@AfterClass
+	static public void deleteFile() {
+		File f = new File(filename);
+		if (f.exists()) {
+			if (!f.delete()) {
+				Assert.fail("Could not delete external resource " + filename);
+			}
+		}
+	}
+
+	@Before
+	public void before() throws InterruptedException {
+		testName = getClass().getSimpleName();
+		System.err.println("In Before of " + testName);
+	}
+
+	@After
+	public void after() throws InterruptedException {
+		System.err.println("In After of " + testName);
+	}
+
+	@Test
+	public void testCountTest() {
+		File f = new File(filename);
+		try {
+			String contents = FileUtils.readFileToString(f);
+			Integer count = Integer.parseInt(contents);
+			if (count++ < 1) {
+				FileUtils.writeStringToFile(f, count.toString());
+				Assert.fail("Have not run test enough times");
+			}
+		} catch (IOException e) {
+			Assert.fail("Could not read from file: " + filename);
+		}
+	}
+
+	@Test
+	public void testTimeoutSuccess() throws InterruptedException {
+		System.err.println("In Tests");
+		Thread.sleep(500);
+	}
+
+	@Ignore("This test used to test timing out, it is expected to fail")
+	@Test
+	public void testTimeoutFail() throws InterruptedException {
+		System.err.println("In Tests");
+		Thread.sleep(2000);
+	}
+
+	// Make sure I didn't break the expected exception annotation
+	@Test(expected = AssertionError.class)
+	public void expectedFailTest() {
+		Assert.assertTrue(false);
+	}
+
+}

--- a/src/test/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunnerUnitTest.java
+++ b/src/test/java/com/sugarcrm/candybean/candybeanRunner/CandybeanRunnerUnitTest.java
@@ -1,0 +1,112 @@
+package com.sugarcrm.candybean.candybeanRunner;
+
+import com.sugarcrm.candybean.exceptions.CandybeanException;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runners.model.InitializationError;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+public class CandybeanRunnerUnitTest extends CandybeanRunner {
+	public CandybeanRunnerUnitTest() throws InitializationError, CandybeanException {
+		super(CandybeanRunnerUnitTest.class);
+	}
+
+	private class CallMock {
+		public boolean called = false;
+		public boolean completed = false;
+		public void call() {
+			called = completed = true;
+		}
+		public void callFail() throws ExecutionException {
+			called = completed = true;
+			Throwable throwable = new Throwable("Test Failed");
+			throw new ExecutionException(throwable);
+		}
+		public void callInteruptedFail() throws InterruptedException {
+			called = completed = true;
+			throw new InterruptedException("Test Interrupted");
+		}
+		public void callDelay() throws InterruptedException {
+			called = true;
+			Thread.sleep(2000);
+			completed = true;
+			throw new InterruptedException("Test Interrupted");
+		}
+	}
+
+	@Test
+	public void TestResultTest() {
+		Assert.assertTrue(TestResult.Success().passed());
+		Assert.assertFalse(TestResult.Success().failed());
+		Assert.assertTrue(TestResult.Fail(new Throwable()).failed());
+		Assert.assertFalse(TestResult.Fail(new Throwable()).passed());
+		Throwable testThrowable = new Throwable("Test Throw");
+		Assert.assertEquals(testThrowable, TestResult.Fail(testThrowable).getThrowable());
+	}
+
+	@Test
+	public void attemptTestPassedTest() throws InitializationError {
+		final CallMock mock = new CallMock();
+
+		final Callable<Void> runTest = new Callable<Void>() {
+			public Void call() throws Exception {
+				mock.call();
+				return null;
+			}
+		};
+		TestResult result = attemptTest(null, runTest, null);
+		Assert.assertTrue(mock.called);
+		Assert.assertTrue(result.passed());
+	}
+
+	@Test
+	public void attemptTestFailedTest() throws InitializationError {
+		final CallMock mock = new CallMock();
+
+		final Callable<Void> runTest = new Callable<Void>() {
+			public Void call() throws Exception {
+				mock.callFail();
+				return null;
+			}
+		};
+		TestResult result = attemptTest(null, runTest, null);
+		Assert.assertTrue(mock.called);
+		Assert.assertTrue(result.failed());
+		Assert.assertEquals("java.lang.Throwable: Test Failed", result.getThrowable().getMessage());
+	}
+
+	@Test
+	public void attemptTestInterruptedTest() throws InitializationError {
+		final CallMock mock = new CallMock();
+
+		final Callable<Void> runTest = new Callable<Void>() {
+			public Void call() throws Exception {
+				mock.callInteruptedFail();
+				return null;
+			}
+		};
+		TestResult result = attemptTest(null, runTest, null);
+		Assert.assertTrue(mock.called);
+		Assert.assertTrue(result.failed());
+		Assert.assertEquals("Test Interrupted", result.getThrowable().getMessage());
+	}
+
+	@Test
+	public void attemptTestTimeout() throws InitializationError {
+		final CallMock mock = new CallMock();
+
+		final Callable<Void> runTest = new Callable<Void>() {
+			public Void call() throws Exception {
+				mock.callDelay();
+				return null;
+			}
+		};
+		TestResult result = attemptTest(null, runTest, null);
+		Assert.assertTrue(mock.called);
+		Assert.assertFalse(mock.completed);
+		Assert.assertTrue(result.failed());
+		Assert.assertEquals("null exceeded allocated runtime of 1500ms", result.getThrowable().getMessage());
+	}
+}

--- a/src/test/java/com/sugarcrm/candybean/configuration/LoggerUnitTest.java
+++ b/src/test/java/com/sugarcrm/candybean/configuration/LoggerUnitTest.java
@@ -30,7 +30,7 @@ public class LoggerUnitTest {
 	
 	@BeforeClass
 	public static void setUp() throws Exception {
-		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.DEFAULT_CONFIG_FILE);
+		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.getDefaultConfigFile());
 		Configuration candybeanConfig = new Configuration(new File(Utils.adjustPath(candybeanConfigStr)));
 		candybean = Candybean.getInstance(candybeanConfig);
 	}

--- a/src/test/java/com/sugarcrm/candybean/examples/sugar/SugarTest.java
+++ b/src/test/java/com/sugarcrm/candybean/examples/sugar/SugarTest.java
@@ -61,7 +61,7 @@ public class SugarTest {
 	}
 	
 	private static Candybean getCandybean() throws Exception {
-		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.DEFAULT_CONFIG_FILE);
+		String candybeanConfigStr = System.getProperty(Candybean.CONFIG_KEY, Candybean.getDefaultConfigFile());
 		Configuration candybeanConfig = new Configuration(new File(Utils.adjustPath(candybeanConfigStr)));
 		return Candybean.getInstance(candybeanConfig);
 	}


### PR DESCRIPTION
Both timeouts and retries are working and can be set in the config file
- Added additional settings (rerun if timed out, run after if timed out)
- Cleaned up code/logic
- Fixed wrapping of errors so they pass on non wrapped errors
- Added options for the location of the config

Test run [here](http://ci/view/Voodoo/job/Voodoo_CB_Custom_Full_Tests/36/)
Test run without enabling the runner (Only the junit change) [here](http://ci/view/Voodoo/job/Voodoo_CB_Custom_Full/47/)
Results using the runner were about 1% better, just under 30 additional tests passed with retries
and timing out enabled. 