### PR TITLE
CB-244: Fixed Wait Until

### DIFF
--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverPause.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverPause.java
@@ -67,8 +67,8 @@ public class WebDriverPause {
 	public Object waitUntil(ExpectedCondition condition, long timeoutMs) throws CandybeanException {
 		// This is done by double-polling. WebDriverWait waits for wdPollingInterval amount of time.
 		// This is done repetitively until the time reaches timeoutMs.
-		long timeoutS = timeoutMs * 1000;
-		long pollingIntervalS = timeoutS <= defaultPollingIntervalS ? timeoutS : defaultPollingIntervalS;
+		final long pollingIntervalS = Math.min(defaultPollingIntervalS,  Math.max(timeoutMs/1000, 1));
+		final long seleniumPollingIntervalMs = 250;
 		final long startTime = currentTimeMillis();
 		long currentTimeMs, currentTimeS = 0;
 		String toThrow = null;
@@ -79,7 +79,7 @@ public class WebDriverPause {
 				currentTimeS = currentTimeMs / 1000;
 				logger.info(currentTimeS + " seconds have passed. Waiting until " + condition.toString() +
 						" is satisfied.");
-				toReturn = (new WebDriverWait(this.wd, pollingIntervalS)).until(condition);
+				toReturn = (new WebDriverWait(this.wd, pollingIntervalS, seleniumPollingIntervalMs)).until(condition);
 				toThrow = null;
 				break;
 			} catch (WebDriverException wdException) {

--- a/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverPause.java
+++ b/src/main/java/com/sugarcrm/candybean/automation/webdriver/WebDriverPause.java
@@ -61,7 +61,7 @@ public class WebDriverPause {
 	 * Accepts any ExpectedCondition and poll under this condition is satisfied within timeout
 	 * @param timeoutMs	Timeout in Milliseconds
 	 * @param condition	The condition to poll
-	 * @return			Returning the object that is returned from ExpectedCondition when the condition is met
+	 * @return Returning the object that is returned from ExpectedCondition when the condition is met
 	 * @throws CandybeanException
 	 */
 	public Object waitUntil(ExpectedCondition condition, long timeoutMs) throws CandybeanException {
@@ -70,27 +70,24 @@ public class WebDriverPause {
 		final long pollingIntervalS = Math.min(defaultPollingIntervalS,  Math.max(timeoutMs/1000, 1));
 		final long seleniumPollingIntervalMs = 250;
 		final long startTime = currentTimeMillis();
-		long currentTimeMs, currentTimeS = 0;
 		String toThrow = null;
 		Object toReturn = null;
 
-		while((currentTimeMs = currentTimeMillis() - startTime) <= timeoutMs) {
+		logger.info("Waiting until " + condition.toString() + " is satisfied.");
+		while(currentTimeMillis() - startTime <= timeoutMs) {
 			try {
-				currentTimeS = currentTimeMs / 1000;
-				logger.info(currentTimeS + " seconds have passed. Waiting until " + condition.toString() +
-						" is satisfied.");
 				toReturn = (new WebDriverWait(this.wd, pollingIntervalS, seleniumPollingIntervalMs)).until(condition);
 				toThrow = null;
 				break;
 			} catch (WebDriverException wdException) {
+				logger.info(currentTimeMillis() - startTime+ "ms have passed. Waiting until " + condition.toString() + " is satisfied.");
 				toThrow = wdException.toString();
 			}
 		}
 
 		if(toThrow != null) {
-			logger.severe("The timeout " + currentTimeS + " seconds have reached. Throwing Exception.");
-			throw new CandybeanException(toThrow.replaceAll("(.*Timed out after )[0-9]+( seconds.*)",
-					"$1" + currentTimeS + "$2"));
+			logger.severe("The timeout of " + timeoutMs + "ms was reached. Throwing Exception.");
+			throw new CandybeanException("Timed out after "+ timeoutMs + " seconds");
 		}
 
 		return toReturn;


### PR DESCRIPTION
The way we were setting waits in webDriverPause is incorrect (I believe modern physics divides by 1000 when converting milliseconds to seconds).

This changes lets waitUntil properly double poll without always using the default value. However, this wait is still affect by the Selenium implicit wait and if that is set, the 250 second poll will have no effect as the implicit wait will override it.

I also changed the logging message so that it would stop saying "0 seconds have passed" on the first poll.

Tests:
[Part 1](http://ci/view/Voodoo/job/Voodoo_CB_Custom/110/)
[Part 2](http://ci/view/Voodoo/job/Voodoo_CB_Custom/111/)